### PR TITLE
Feature/STweep

### DIFF
--- a/Sequencer/Sequencer/TcSequencer/DUTs/SequenceType.TcDUT
+++ b/Sequencer/Sequencer/TcSequencer/DUTs/SequenceType.TcDUT
@@ -1,26 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <DUT Name="SequenceType" Id="{1c6f9a7b-ac96-482b-b10c-fb203e245e23}">
-    <Declaration><![CDATA[TYPE SequenceType :
-STRUCT
-	startStep : ENUM;  //The step when doStep was called
-	currentStep :ENUM;
-	lastRequestNumber : DINT;
+    <Declaration><![CDATA[TYPE
+    SequenceType :
+    STRUCT
+        startStep : ENUM; //The step when doStep was called
+        currentStep : ENUM;
+        lastRequestNumber : DINT;
 
-	onEntry : BOOL;
-	onExit : BOOL;
+        onEntry : BOOL;
+        onExit : BOOL;
 
-	statusChecked : BOOL;
-	isDone : BOOL;
-	isAbort : BOOL;
-	isError : BOOL;
+        statusChecked : BOOL;
+        isDone : BOOL;
+        isAbort : BOOL;
+        isError : BOOL;
 
-	stepHandler : IStepManager;
-	activeTasks : PLCOpenCallGroup; 	
+        stepHandler : IStepManager;
+        activeTasks : PLCOpenCallGroup;
 
-	errorHandled : BOOL;
+        errorHandled : BOOL;
 
-END_STRUCT
+    END_STRUCT
 END_TYPE
 ]]></Declaration>
   </DUT>

--- a/Sequencer/Sequencer/TcSequencer/Interfaces/ISequence.TcIO
+++ b/Sequencer/Sequencer/TcSequencer/Interfaces/ISequence.TcIO
@@ -16,13 +16,12 @@ PROPERTY CurrentStep : ENUM]]></Declaration>
       <Declaration><![CDATA[METHOD doStep : ENUM
 VAR
 END_VAR
-
 ]]></Declaration>
     </Method>
     <Method Name="onAbort" Id="{4445ff1a-fbfc-4467-ae59-52d6282d62cc}" FolderPath="callbacks\">
       <Declaration><![CDATA[METHOD onAbort : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
     </Method>
@@ -35,7 +34,7 @@ END_VAR
     <Method Name="onError" Id="{bcf3cc66-e294-4626-a88a-229a42065635}" FolderPath="callbacks\">
       <Declaration><![CDATA[METHOD onError : BOOL
 VAR_INPUT
-	nextStep : ENUM;	
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
     </Method>
@@ -48,36 +47,36 @@ END_VAR
     <Method Name="onFailure" Id="{0fd686e6-f999-4918-9b3d-8a51abb3cd5a}" FolderPath="callbacks\">
       <Declaration><![CDATA[METHOD onFailure : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
     </Method>
     <Method Name="onSuccess" Id="{82c8d03a-450e-4fab-9845-0d89e2f94a52}" FolderPath="callbacks\">
       <Declaration><![CDATA[METHOD onSuccess : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
     </Method>
     <Method Name="requestStep" Id="{eda50567-af34-458e-89ce-ac3a3abf3610}" FolderPath="StateControl\">
       <Declaration><![CDATA[METHOD requestStep : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
     </Method>
     <Method Name="requestStepClear" Id="{e59012ec-24ed-47da-8aaf-87ba4a553cbc}" FolderPath="StateControl\">
       <Declaration><![CDATA[METHOD requestStepClear : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
     </Method>
     <Method Name="sequenceAbort" Id="{53bba82b-ae56-4f65-8efe-cc2958f21910}" FolderPath="StateControl\">
       <Declaration><![CDATA[METHOD sequenceAbort : BOOL
 VAR_INPUT
-	ErrorCode : DINT;
-	ErrorMessage: STRING;
+    ErrorCode : DINT;
+    ErrorMessage : STRING;
 END_VAR
 ]]></Declaration>
     </Method>
@@ -90,8 +89,8 @@ END_VAR
     <Method Name="sequenceError" Id="{efd40ff7-83f9-47af-a16c-c4732fe53c27}" FolderPath="StateControl\">
       <Declaration><![CDATA[METHOD sequenceError : BOOL
 VAR_INPUT
-	ErrorCode : DINT;
-	ErrorMessage: STRING;
+    ErrorCode : DINT;
+    ErrorMessage : STRING;
 END_VAR
 ]]></Declaration>
     </Method>

--- a/Sequencer/Sequencer/TcSequencer/Interfaces/IStepManager.TcIO
+++ b/Sequencer/Sequencer/TcSequencer/Interfaces/IStepManager.TcIO
@@ -6,7 +6,7 @@
     <Method Name="_requestStep" Id="{484e6cd7-60ba-4268-b695-64585da66145}">
       <Declaration><![CDATA[METHOD _requestStep : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
     </Method>

--- a/Sequencer/Sequencer/TcSequencer/POUs/Sequencer.TcPOU
+++ b/Sequencer/Sequencer/TcSequencer/POUs/Sequencer.TcPOU
@@ -3,12 +3,12 @@
   <POU Name="Sequencer" Id="{6cce11bf-bf75-4b96-8542-c7369e25211e}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK Sequencer IMPLEMENTS ISequence, IPLCOpenCall, IPlugin, IPLCOpenCommand
 VAR
-	i_sequence : SequenceType;
-	startStep : ENUM;
-	forceStart : BOOL;
-	forceDone : BOOL;
-	forceError : BOOL;	
-	baseManager : StepManagerBasic;
+    i_sequence : SequenceType;
+    startStep : ENUM;
+    forceStart : BOOL;
+    forceDone : BOOL;
+    forceError : BOOL;
+    baseManager : StepManagerBasic;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -36,7 +36,7 @@ i_sequence.activeTasks.Aborted();]]></ST>
       <Declaration><![CDATA[{warning 'add method implementation '}
 METHOD AbortPreviousCommands : BOOL
 VAR_INPUT
-	newCommand	: IPLCOpenCommand;
+    newCommand : IPLCOpenCommand;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -48,19 +48,19 @@ END_VAR
     <Method Name="checkStatus" Id="{6b7c3f12-8739-4096-9480-9fa604b0d507}" FolderPath="PLCOpenCaller\">
       <Declaration><![CDATA[METHOD PRIVATE checkStatus : BOOL
 VAR
-	_commandIndex : INT;
-	_anyAbort : BOOL;
-	_anyBusy : BOOL;
-	_anyError : BOOL;
+    _commandIndex : INT;
+    _anyAbort : BOOL;
+    _anyBusy : BOOL;
+    _anyError : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF NOT i_sequence.statusChecked THEN
-	// Cache the abort so there's a consistent status for the whole state
-	i_sequence.isError := i_sequence.activeTasks.isError;
-	i_sequence.isAbort := i_sequence.activeTasks.isAbort;
-	i_sequence.isDone := i_sequence.activeTasks.isDone;
+    // Cache the abort so there's a consistent status for the whole state
+    i_sequence.isError := i_sequence.activeTasks.isError;
+    i_sequence.isAbort := i_sequence.activeTasks.isAbort;
+    i_sequence.isDone := i_sequence.activeTasks.isDone;
 END_IF
 ]]></ST>
       </Implementation>
@@ -97,26 +97,26 @@ currentStep := i_sequence.stepHandler.currentStep;]]></ST>
       <Declaration><![CDATA[METHOD doStep : ENUM
 VAR
 END_VAR
-
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF forceStart THEN
-	forceStart := FALSE;
-	i_sequence.stepHandler._requestStep(startStep);
+    forceStart := FALSE;
+    i_sequence.stepHandler._requestStep(startStep);
 END_IF
 
 i_sequence.currentStep := i_sequence.stepHandler.currentStep;
+
 //If the current step has changed,
 //	Set the flag for onEntry()
 IF i_sequence.stepHandler.RequestNumber <> i_sequence.lastRequestNumber THEN
-	
-	i_sequence.lastRequestNumber := i_sequence.stepHandler.RequestNumber;
-	i_sequence.onEntry := TRUE;
-	i_sequence.onExit := FALSE;
+
+    i_sequence.lastRequestNumber := i_sequence.stepHandler.RequestNumber;
+    i_sequence.onEntry := TRUE;
+    i_sequence.onExit := FALSE;
 ELSE
-	i_sequence.onEntry := FALSE;	
+    i_sequence.onEntry := FALSE;
 END_IF
 
 //The start step is used to detect if the 
@@ -128,17 +128,17 @@ i_sequence.statusChecked := FALSE;
 i_sequence.errorHandled := FALSE;
 
 IF i_sequence.onExit THEN
-	doStep := SEQUENCE_STEP.NO_STEP;
-ELSE		
-	//Return the state
-	doStep := i_sequence.currentStep;
+    doStep := SEQUENCE_STEP.NO_STEP;
+ELSE
+    //Return the state
+    doStep := i_sequence.currentStep;
 END_IF]]></ST>
       </Implementation>
     </Method>
     <Method Name="Errored" Id="{d625b5cc-7ecf-4617-9302-d9a3a7aca5f7}" FolderPath="PLCOpenCaller\">
       <Declaration><![CDATA[METHOD Errored : BOOL
 VAR_INPUT
-	ID	: INT;
+    ID : INT;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -165,18 +165,18 @@ END_VAR
     <Method Name="FB_init" Id="{f87966c2-0adb-4c01-87f6-71b336bb9cc0}">
       <Declaration><![CDATA[METHOD FB_init : BOOL
 VAR_INPUT
-	bInitRetains : BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
-	bInCopyCode : BOOL;  // if TRUE, the instance afterwards gets moved into the copy code (online change)
-	stepHandler : IStepManager;
+    bInitRetains : BOOL; // if TRUE, the retain variables are initialized (warm start / cold start)
+    bInCopyCode : BOOL; // if TRUE, the instance afterwards gets moved into the copy code (online change)
+    stepHandler : IStepManager;
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF stepHandler = 0 THEN
-	i_sequence.stepHandler := baseManager;
+    i_sequence.stepHandler := baseManager;
 ELSE
-	i_sequence.stepHandler := stepHandler;
+    i_sequence.stepHandler := stepHandler;
 END_IF]]></ST>
       </Implementation>
     </Method>
@@ -231,7 +231,7 @@ isError := i_sequence.isError;]]></ST>
     <Method Name="onAbort" Id="{124a7554-7af0-48f3-9c3b-c6fcfb012c1a}" FolderPath="API\Decisions\">
       <Declaration><![CDATA[METHOD onAbort : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -241,22 +241,22 @@ END_VAR
 
 IF isAbort THEN
 
-	IF nextStep >= 0 THEN
-		LogMessage( 1, 'Step Abort');
-		i_sequence.errorHandled := TRUE;
-		setNextStep( nextStep );
-	END_IF
+    IF nextStep >= 0 THEN
+        LogMessage(1, 'Step Abort');
+        i_sequence.errorHandled := TRUE;
+        setNextStep(nextStep);
+    END_IF
 
-	onAbort := TRUE;
+    onAbort := TRUE;
 ELSE
-	onAbort := FALSE;		
+    onAbort := FALSE;
 END_IF]]></ST>
       </Implementation>
     </Method>
     <Method Name="onEntry" Id="{d5293258-9127-40f2-8767-4af37daea8dd}" FolderPath="API\StateTransition\">
       <Declaration><![CDATA[METHOD onEntry : BOOL
 VAR
-	sequencer : Sequencer(0);
+    sequencer : Sequencer(0);
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -269,33 +269,33 @@ onEntry := i_sequence.onEntry;]]></ST>
     <Method Name="onError" Id="{2b381ad0-9511-4a2a-a59b-89ff6fa0eadc}" FolderPath="API\Decisions\">
       <Declaration><![CDATA[METHOD onError : BOOL
 VAR_INPUT
-	nextStep : ENUM;	
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF isError THEN
-	IF nextStep >= 0 THEN
-		LogMessage( 1, 'Step Abort');
-		i_sequence.errorHandled := TRUE;
-		setNextStep( nextStep );
-	END_IF
-	onError := TRUE;
+    IF nextStep >= 0 THEN
+        LogMessage(1, 'Step Abort');
+        i_sequence.errorHandled := TRUE;
+        setNextStep(nextStep);
+    END_IF
+
+    onError := TRUE;
 ELSE
-	onError := FALSE;		
+    onError := FALSE;
 END_IF]]></ST>
       </Implementation>
     </Method>
     <Method Name="onExit" Id="{f59d2d40-7d9d-447e-9f98-0b5c912393f5}" FolderPath="API\StateTransition\">
       <Declaration><![CDATA[METHOD onExit : BOOL
 VAR
-	sequencer : Sequencer(0);
+    sequencer : Sequencer(0);
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
-
 
 //If the current step has since the doStep
 onExit := i_sequence.onExit;
@@ -305,43 +305,43 @@ onExit := i_sequence.onExit;
     <Method Name="onFailure" Id="{8864cad6-d51a-434b-b76a-3fb1f56e20e0}" FolderPath="API\Decisions\">
       <Declaration><![CDATA[METHOD onFailure : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF i_sequence.activeTasks.isAbort OR i_sequence.activeTasks.isError THEN
-	//On failure will not set the step if a more specific handler already set the step
-	IF i_sequence.errorHandled = FALSE AND nextStep >= 0 THEN
-		LogMessage( 1, 'Step Failure');
-		setNextStep( nextStep );
-	END_IF
+    //On failure will not set the step if a more specific handler already set the step
+    IF i_sequence.errorHandled = FALSE AND nextStep >= 0 THEN
+        LogMessage(1, 'Step Failure');
+        setNextStep(nextStep);
+    END_IF
 
-	onFailure := TRUE;
+    onFailure := TRUE;
 ELSE
-	onFailure := FALSE;		
+    onFailure := FALSE;
 END_IF]]></ST>
       </Implementation>
     </Method>
     <Method Name="onSuccess" Id="{2bf2939a-63ed-4f80-94f9-d2fc5becbe2f}" FolderPath="API\Decisions\">
       <Declaration><![CDATA[METHOD onSuccess : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF i_sequence.activeTasks.isDone THEN
-	IF nextStep >= 0 THEN
-		LogMessage( 1, 'Step Success');
-		setNextStep( nextStep );
-	END_IF
-	
-	onSuccess := TRUE;
+    IF nextStep >= 0 THEN
+        LogMessage(1, 'Step Success');
+        setNextStep(nextStep);
+    END_IF
+
+    onSuccess := TRUE;
 ELSE
-	onSuccess := FALSE;		
+    onSuccess := FALSE;
 END_IF
 ]]></ST>
       </Implementation>
@@ -350,7 +350,7 @@ END_IF
       <Declaration><![CDATA[{warning 'add method implementation '}
 METHOD registerGroup : BOOL
 VAR_INPUT
-	group	: IPLCOpenGroup;
+    group : IPLCOpenGroup;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -387,7 +387,7 @@ END_VAR
     <Method Name="requestStep" Id="{b48e0562-c987-4989-8061-de7cf0c6fe2a}" FolderPath="API\StateControl\">
       <Declaration><![CDATA[METHOD requestStep : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -401,7 +401,7 @@ i_sequence.onExit := TRUE;
     <Method Name="requestStepClear" Id="{a486ef5e-3d7c-419f-8255-b0a39dabc8fc}" FolderPath="API\StateControl\">
       <Declaration><![CDATA[METHOD requestStepClear : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -423,8 +423,8 @@ THIS^();]]></ST>
     <Method Name="sequenceAbort" Id="{cc629ce3-ace3-4ca4-872b-7b49e09a5e57}" FolderPath="API\StateControl\">
       <Declaration><![CDATA[METHOD sequenceAbort : BOOL
 VAR_INPUT
-	ErrorCode : DINT;
-	ErrorMessage: STRING;
+    ErrorCode : DINT;
+    ErrorMessage : STRING;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -453,8 +453,8 @@ i_sequence.onExit := TRUE;
     <Method Name="sequenceError" Id="{06555983-6dc8-4375-b176-7e8590c26dcd}" FolderPath="API\StateControl\">
       <Declaration><![CDATA[METHOD sequenceError : BOOL
 VAR_INPUT
-	ErrorCode : DINT;
-	ErrorMessage: STRING;
+    ErrorCode : DINT;
+    ErrorMessage : STRING;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -469,7 +469,7 @@ i_sequence.onExit := TRUE;
     <Method Name="setNextStep" Id="{c0c17481-86c4-4051-a78b-3b1ee372be58}" FolderPath="internal\">
       <Declaration><![CDATA[METHOD PROTECTED setNextStep
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -482,20 +482,20 @@ i_sequence.stepHandler._requestStep(nextStep);
     <Method Name="Start" Id="{52f1f4d2-13d6-46fb-aa1f-c1affcffbade}" FolderPath="PLCOpenCaller\">
       <Declaration><![CDATA[METHOD Start : BOOL
 VAR_INPUT
-	Command	: IPLCOpenCommand;
+    Command : IPLCOpenCommand;
 END_VAR
 VAR
-	_commandIndex : INT;
+    _commandIndex : INT;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
 IF i_sequence.activeTasks.Start(Command) = 0 THEN
-	// TODO: All out of commands.. Throw an error
-	sequenceError( 10000, 'Too Many Commands in 1 step');
-	Start :=  FALSE;
+    // TODO: All out of commands.. Throw an error
+    sequenceError(10000, 'Too Many Commands in 1 step');
+    Start := FALSE;
 ELSE
-	Start :=  TRUE;	
+    Start := TRUE;
 END_IF
 ]]></ST>
       </Implementation>

--- a/Sequencer/Sequencer/TcSequencer/POUs/StepManagerBasic.TcPOU
+++ b/Sequencer/Sequencer/TcSequencer/POUs/StepManagerBasic.TcPOU
@@ -4,8 +4,8 @@
     <Declaration><![CDATA[{attribute 'enable_dynamic_creation'}
 FUNCTION_BLOCK StepManagerBasic IMPLEMENTS IStepManager
 VAR
-	_currentStep : ENUM;
-	_requestNumber : DINT;
+    _currentStep : ENUM;
+    _requestNumber : DINT;
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
@@ -14,7 +14,7 @@ END_VAR]]></Declaration>
     <Method Name="_requestStep" Id="{631d6933-a3d4-4a04-8d8b-2defab756516}">
       <Declaration><![CDATA[METHOD _requestStep : BOOL
 VAR_INPUT
-	nextStep : ENUM;
+    nextStep : ENUM;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
@@ -38,7 +38,7 @@ _currentStep := SEQUENCE_STEP.NO_STEP;]]></ST>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
-_requestNumber := _requestNumber + 1; 
+_requestNumber := _requestNumber + 1;
 _currentStep := SEQUENCE_STEP.NO_STEP;]]></ST>
       </Implementation>
     </Method>
@@ -48,7 +48,7 @@ _currentStep := SEQUENCE_STEP.NO_STEP;]]></ST>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
 
-_requestNumber := _requestNumber + 1; 
+_requestNumber := _requestNumber + 1;
 _currentStep := SEQUENCE_STEP.NO_STEP;]]></ST>
       </Implementation>
     </Method>

--- a/Sequencer/Sequencer/TcSequencer/Test/FB_Sequencer_Test.TcPOU
+++ b/Sequencer/Sequencer/TcSequencer/Test/FB_Sequencer_Test.TcPOU
@@ -19,9 +19,9 @@ CurrentAndRequestStep();]]></ST>
     <Method Name="CurrentAndRequestStep" Id="{00c73c39-e570-45cb-8831-bed7304ddd26}">
       <Declaration><![CDATA[METHOD CurrentAndRequestStep
 VAR
-	sequencer : Sequencer(0);
-	Command : PLCOpenCommand();
-	step : UDINT;
+    sequencer : Sequencer(0);
+    Command : PLCOpenCommand();
+    step : UDINT;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -45,8 +45,8 @@ TEST_FINISHED();]]></ST>
     <Method Name="OnAbort" Id="{756190d0-8aa4-4061-8aca-7e61a0ad15cd}">
       <Declaration><![CDATA[METHOD OnAbort
 VAR
-	sequencer : Sequencer(0);
-	outputVal : BOOL;
+    sequencer : Sequencer(0);
+    outputVal : BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -69,8 +69,8 @@ VAR_INPUT
 END_VAR
 
 VAR
-	sequencer : Sequencer(0);
-	outputVal: BOOL;
+    sequencer : Sequencer(0);
+    outputVal : BOOL;
 END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[// Copyright (c) 2024 Loupe (https://loupe.team), provided under the MIT License.
@@ -91,8 +91,8 @@ TEST_FINISHED();]]></ST>
     <Method Name="OnError" Id="{ceefdcc0-adb1-4ad8-928a-8e1e77a9bfee}">
       <Declaration><![CDATA[METHOD OnError
 VAR
-	sequencer : Sequencer(0);
-	outputVal : BOOL;
+    sequencer : Sequencer(0);
+    outputVal : BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -112,7 +112,7 @@ TEST_FINISHED();]]></ST>
     <Method Name="OnSuccess" Id="{6a55c547-d864-42a2-86db-036e6aa1ad13}">
       <Declaration><![CDATA[METHOD OnSuccess
 VAR_INPUT
-	sequencer : Sequencer(0);
+    sequencer : Sequencer(0);
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -136,8 +136,8 @@ TEST_FINISHED();]]></ST>
     <Method Name="Start" Id="{3d524a28-168c-402c-a8b1-706368e2797f}">
       <Declaration><![CDATA[METHOD Start
 VAR
-	sequencer : Sequencer(0);
-	output : BOOL;
+    sequencer : Sequencer(0);
+    output : BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/Sequencer/Sequencer/TcSequencer/Test/FB_StepManagerBasic_Test.TcPOU
+++ b/Sequencer/Sequencer/TcSequencer/Test/FB_StepManagerBasic_Test.TcPOU
@@ -19,7 +19,7 @@ Reset();
     <Method Name="RequestStep" Id="{198c2120-5857-4c31-b6b8-c5eeca56d028}">
       <Declaration><![CDATA[METHOD RequestStep
 VAR
-	step_manager : StepManagerBasic();
+    step_manager : StepManagerBasic();
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -36,7 +36,7 @@ TEST_FINISHED();]]></ST>
     <Method Name="Reset" Id="{f87175cc-f817-48db-aeb6-5cea267ae2ed}">
       <Declaration><![CDATA[METHOD Reset
 VAR
-	step_manager : StepManagerBasic();
+    step_manager : StepManagerBasic();
 END_VAR
 ]]></Declaration>
       <Implementation>

--- a/Sequencer/Sequencer/TcSequencer/Test/PRGTEST.TcPOU
+++ b/Sequencer/Sequencer/TcSequencer/Test/PRGTEST.TcPOU
@@ -3,8 +3,8 @@
   <POU Name="PRGTEST" Id="{cb0dada2-790f-48b3-8702-fc17bd7e66f5}" SpecialFunc="None">
     <Declaration><![CDATA[PROGRAM PRGTEST
 VAR
-	sequencer_test : FB_Sequencer_Test;
-	step_manager_test : FB_StepManagerBasic_Test;
+    sequencer_test : FB_Sequencer_Test;
+    step_manager_test : FB_StepManagerBasic_Test;
 END_VAR
 ]]></Declaration>
     <Implementation>


### PR DESCRIPTION
Apply default STweep formatting across the entire library, except for tests.
The canonical indent in tests doesn't get respected by STweep, there may be a way to configure this, but for now I've simply disabled STweep in those files by adding the
(*STweep.Disable*) comment